### PR TITLE
updated setup.py - see merge request comment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,21 @@
+import re
+import ast
 from setuptools import setup
 import PySignal
 
 
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+_author_re = re.compile(r'__author__\s+=\s+(.*)')
+_email_re = re.compile(r'__email__\s+=\s+(.*)')
+
+
+with open('PySignal.py', 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
+    author = str(ast.literal_eval(_author_re.search(
+        f.read().decode('utf-8')).group(1)))
+    email = str(ast.literal_eval(_email_re.search(
+        f.read().decode('utf-8')).group(1)))
 
 
 classifiers = [
@@ -22,10 +36,10 @@ classifiers = [
 
 setup(
     name="PySignal",
-    version=PySignal.__version__,
+    version=version,
     description="Python Signal Library to mimic the Qt Signal system for event driven connections",
-    author=PySignal.__author__,
-    author_email=PySignal.__email__,
+    author=author,
+    author_email=email,
     url="https://github.com/dgovil/PySignal",
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
"Your setup.py should not import your package for reading the version number. This fails for the end-user. Instead, always read it directly. In this case, I used regular expressions for extracting it. This is up to you. But never import your own module/package"

https://gehrcke.de/2014/02/distributing-a-python-command-line-application/

Feel free to accept or reject it as you see fit - Not everyone follows this, but it is pretty common place.