### PR TITLE
Improve test coverage and related fixes

### DIFF
--- a/PySignal.py
+++ b/PySignal.py
@@ -40,7 +40,9 @@ class Signal(object):
                     method(obj, *args, **kwargs)
             elif isinstance(slot, weakref.ref):
                 # If it's a weakref, call the ref to get the instance and then call the func
-                slot()(*args, **kwargs)
+                # Don't wrap in try/except so we don't risk masking exceptions from the actual func call
+                if (slot() is not None):
+                    slot()(*args, **kwargs)
             else:
                 # Else call it in a standard way. Should be just lambdas at this point
                 slot(*args, **kwargs)
@@ -49,39 +51,60 @@ class Signal(object):
         """
         Connects the signal to any callable object
         """
-        if isinstance(slot, partial) or '<' in slot.__name__:
+        if not callable(slot):
+            raise ValueError("Connection to non-callable '%s' object failed" % slot.__class__.__name__)
+
+        if (isinstance(slot, partial) or '<' in slot.__name__):
             # If it's a partial or a lambda. The '<' check is the only py2 and py3 compatible way I could find
-            self._slots.append(slot)
+            if slot not in self._slots:
+                self._slots.append(slot)
         elif inspect.ismethod(slot):
             # Check if it's an instance method and store it with the instance as the key
             slotSelf = slot.__self__
             slotDict = weakref.WeakKeyDictionary()
             slotDict[slotSelf] = slot.__func__
-            self._slots.append(slotDict)
+            if slotDict not in self._slots:
+                self._slots.append(slotDict)
         else:
             # If it's just a function then just store it as a weakref.
-            self._slots.append(weakref.ref(slot))
+            newSlotRef = weakref.ref(slot)
+            if newSlotRef not in self._slots:
+                self._slots.append(newSlotRef)
 
     def disconnect(self, slot):
         """
         Disconnects the slot from the signal
         """
+        if not callable(slot):
+            return
+
         if inspect.ismethod(slot):
             # If it's a method, then find it by its instance
             slotSelf = slot.__self__
-            for _slot in self._slots:
-                if isinstance(_slot, weakref.WeakKeyDictionary) and slotSelf in _slot:
-                    self._slots.remove(slot)
-        elif slot in self._slots:
+            for s in self._slots:
+                if isinstance(s, weakref.WeakKeyDictionary) and (slotSelf in s) and (s[slotSelf] is slot.__func__):
+                    self._slots.remove(s)
+                    break
+        elif isinstance(slot, partial) or '<' in slot.__name__:
+            # If it's a partial or lambda, try to remove directly
+            try:
                 self._slots.remove(slot)
+            except ValueError:
+                pass
+        else:
+            # It's probably a function, so try to remove by weakref
+            try:
+                self._slots.remove(weakref.ref(slot))
+            except ValueError:
+                pass
 
     def clear(self):
         """Clears the signal of all connected slots"""
         self._slots = []
 
-    def block(self, value):
+    def block(self, isBlocked):
         """Sets blocking of the signal"""
-        self._block = bool(value)
+        self._block = bool(isBlocked)
 
 
 class ClassSignal(object):
@@ -139,12 +162,12 @@ class SignalFactory(dict):
         assert signalName in self, "%s is not a registered signal" % signalName
         self[signalName].connect(slot)
 
-    def block(self, signals=None, state=True):
+    def block(self, signals=None, isBlocked=True):
         """
         Sets the block on any provided signals, or to all signals
 
         :param signals: defaults to all signals. Accepts either a single string or a list of strings
-        :param state: the state to set the signal to
+        :param isBlocked: the state to set the signal to
         """
         if signals:
             try:
@@ -159,7 +182,7 @@ class SignalFactory(dict):
         for signal in signals:
             if signal not in self:
                 raise RuntimeError("Could not find signal matching %s" % signal)
-            self[signal].block(state)
+            self[signal].block(isBlocked)
 
 
 class ClassSignalFactory(object):

--- a/PySignal.py
+++ b/PySignal.py
@@ -21,7 +21,6 @@ class Signal(object):
         self._block = False
         self._slots = []
 
-
     def emit(self, *args, **kwargs):
         """
         Calls all the connected slots with the provided args and kwargs unless block is activated
@@ -60,7 +59,7 @@ class Signal(object):
             slotDict[slotSelf] = slot.__func__
             self._slots.append(slotDict)
         else:
-            # If it's just a function then just store it ass a weakref.
+            # If it's just a function then just store it as a weakref.
             self._slots.append(weakref.ref(slot))
 
     def disconnect(self, slot):
@@ -85,13 +84,13 @@ class Signal(object):
         self._block = bool(value)
 
 
-
 class ClassSignal(object):
     """
     The class signal allows a signal to be set on a class rather than an instance.
     This emulates the behavior of a PyQt signal
     """
     _map = {}
+
     def __get__(self, instance, owner):
         tmp = self._map.setdefault(self, weakref.WeakKeyDictionary())
         return tmp.setdefault(instance, Signal())
@@ -168,6 +167,7 @@ class ClassSignalFactory(object):
     The class signal allows a signal factory to be set on a class rather than an instance.
     """
     _map = {}
+
     def __get__(self, instance, owner):
         tmp = self._map.setdefault(self, weakref.WeakKeyDictionary())
         return tmp.setdefault(instance, SignalFactory())

--- a/tests.py
+++ b/tests.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
 import PySignal
 from functools import partial
+
 try:
     import unittest2 as unittest
 except:
     import unittest
-
 
 
 def testFunc(value):
@@ -15,18 +15,19 @@ def testFunc(value):
     print("Ran for %s" % value)
     SignalTest.checkval = value
 
-class DummySignalClass(object):
-     """A dummy class to check for instance handling of signals"""
-     cSignal = PySignal.ClassSignal()
-     cSignalFactory = PySignal.ClassSignalFactory()
 
-     def __init__(self):
-         self.signal = PySignal.Signal()
-         self.signalFactory = PySignal.SignalFactory()
+class DummySignalClass(object):
+    """A dummy class to check for instance handling of signals"""
+    cSignal = PySignal.ClassSignal()
+    cSignalFactory = PySignal.ClassSignalFactory()
+
+    def __init__(self):
+        self.signal = PySignal.Signal()
+        self.signalFactory = PySignal.SignalFactory()
 
 
 class SignalTest(unittest.TestCase):
-    checkval = None # A state check for the tests
+    checkval = None  # A state check for the tests
 
     def setVal(self, val):
         """A method to test instance settings with"""
@@ -127,7 +128,6 @@ class SignalTest(unittest.TestCase):
 
         dummy.signalFactory['Spam'].emit(202)
         self.assertNotEqual(self.checkval, 202)
-
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -4,16 +4,14 @@ from functools import partial
 
 try:
     import unittest2 as unittest
-except:
+except ImportError:
     import unittest
 
 
-def testFunc(value):
-    """
-    A test standalone function for signals to attach onto
-    """
-    print("Ran for %s" % value)
-    SignalTest.checkval = value
+def testFunc(test, value):
+    """A test standalone function for signals to attach onto"""
+    test.checkval = value
+    test.func_call_count += 1
 
 
 class DummySignalClass(object):
@@ -26,108 +24,425 @@ class DummySignalClass(object):
         self.signalFactory = PySignal.SignalFactory()
 
 
-class SignalTest(unittest.TestCase):
-    checkval = None  # A state check for the tests
+class DummySlotClass(object):
+    """A dummy class to check for slot handling"""
+    checkval = None
 
+    def setVal(self, val):
+        """A method to test slot calls with"""
+        self.checkval = val
+
+
+class SignalTestMixin(object):
+    """Mixin class with common helpers for signal tests"""
+
+    def __init__(self):
+        self.checkval = None  # A state check for the tests
+        self.checkval2 = None  # A state check for the tests
+        self.setVal_call_count = 0  # A state check for the test method
+        self.setVal2_call_count = 0  # A state check for the test method
+        self.func_call_count = 0  # A state check for test function
+
+    def reset(self):
+        self.checkval = None
+        self.checkval2 = None
+        self.setVal_call_count = 0
+        self.setVal2_call_count = 0
+        self.func_call_count = 0
+
+    # Helper methods
     def setVal(self, val):
         """A method to test instance settings with"""
         self.checkval = val
+        self.setVal_call_count += 1
+
+    def setVal2(self, val):
+        """Another method to test instance settings with"""
+        self.checkval2 = val
+        self.setVal2_call_count += 1
 
     def throwaway(self, *args):
         """A method to throw redundant data into"""
         pass
 
-    def test_partialConnect(self):
-        """Tests if signals can connect to partials"""
+
+# noinspection PyProtectedMember
+class SignalTest(unittest.TestCase, SignalTestMixin):
+    """Unit tests for Signal class"""
+
+    def setUp(self):
+        self.reset()
+
+    def __init__(self, methodName='runTest'):
+        unittest.TestCase.__init__(self, methodName)
+        SignalTestMixin.__init__(self)
+
+    def test_PartialConnect(self):
+        """Tests connecting signals to partials"""
         partialSignal = PySignal.Signal()
-        partialSignal.connect(partial(testFunc, 'Partial'))
-        partialSignal.emit()
-        self.assertEqual(self.checkval, 'Partial')
+        partialSignal.connect(partial(testFunc, self, 'Partial'))
+        self.assertEqual(len(partialSignal._slots), 1, "Expected single connected slot")
 
-    def test_lambdaConnect(self):
-        """Tests if signals can be connected to lambdas"""
+    def test_PartialConnectDuplicate(self):
+        """Tests connecting signals to partials"""
+        partialSignal = PySignal.Signal()
+        func = partial(testFunc, self, 'Partial')
+        partialSignal.connect(func)
+        partialSignal.connect(func)
+        self.assertEqual(len(partialSignal._slots), 1, "Expected single connected slot")
+
+    def test_LambdaConnect(self):
+        """Tests connecting signals to lambdas"""
         lambdaSignal = PySignal.Signal()
-        lambdaSignal.connect(lambda value: testFunc(value))
-        lambdaSignal.emit('Lambda')
-        self.assertEqual(self.checkval, 'Lambda')
+        lambdaSignal.connect(lambda value: testFunc(self, value))
+        self.assertEqual(len(lambdaSignal._slots), 1, "Expected single connected slot")
 
-    def printer(self, value=2):
-        """Dummy printer method for signals to connect to"""
-        print("Method called with %s" % value)
-        SignalTest.checkval = value
+    def test_LambdaConnectDuplicate(self):
+        """Tests connecting signals to duplicate lambdas"""
+        lambdaSignal = PySignal.Signal()
+        func = lambda value: testFunc(self, value)
+        lambdaSignal.connect(func)
+        lambdaSignal.connect(func)
+        self.assertEqual(len(lambdaSignal._slots), 1, "Expected single connected slot")
 
-    def test_methodConnect(self):
-        """Test if signals can be connected to methods on class instances"""
+    def test_MethodConnect(self):
+        """Test connecting signals to methods on class instances"""
         methodSignal = PySignal.Signal()
-        methodSignal.connect(self.printer)
-        methodSignal.emit(value=5)
-        self.assertEqual(self.checkval, 5)
+        methodSignal.connect(self.setVal)
+        self.assertEqual(len(methodSignal._slots), 1, "Expected single connected slot")
 
-    def test_functionConnect(self):
-        """Test if signals can be connected to standalone functions"""
+    def test_MethodConnectDuplicate(self):
+        """Test that each method connection is unique"""
+        methodSignal = PySignal.Signal()
+        methodSignal.connect(self.setVal)
+        methodSignal.connect(self.setVal)
+        self.assertEqual(len(methodSignal._slots), 1, "Expected single connected slot")
+
+    def test_MethodConnectDifferentInstances(self):
+        """Test connecting the same method from different instances"""
+        methodSignal = PySignal.Signal()
+        dummy1 = DummySlotClass()
+        dummy2 = DummySlotClass()
+        methodSignal.connect(dummy1.setVal)
+        methodSignal.connect(dummy2.setVal)
+        self.assertEqual(len(methodSignal._slots), 2, "Expected two connected slots")
+
+    def test_FunctionConnect(self):
+        """Test connecting signals to standalone functions"""
         funcSignal = PySignal.Signal()
         funcSignal.connect(testFunc)
-        funcSignal.emit("Function")
-        self.assertEqual(self.checkval, 'Function')
+        self.assertEqual(len(funcSignal._slots), 1, "Expected single connected slot")
 
-    def test_signalEmit(self):
-        """Test if a signal can be emitted"""
+    def test_FunctionConnectDuplicate(self):
+        """Test that each function connection is unique"""
+        funcSignal = PySignal.Signal()
+        funcSignal.connect(testFunc)
+        funcSignal.connect(testFunc)
+        self.assertEqual(len(funcSignal._slots), 1, "Expected single connected slot")
+
+    def test_ConnectNonCallable(self):
+        """Test connecting non-callable object"""
+        nonCallableSignal = PySignal.Signal()
+        with self.assertRaises(ValueError):
+            nonCallableSignal.connect(self.checkval)
+
+    def test_EmitToPartial(self):
+        """Test emitting signals to partial"""
+        partialSignal = PySignal.Signal()
+        partialSignal.connect(partial(testFunc, self, 'Partial'))
+        partialSignal.emit()
+        self.assertEqual(self.checkval, 'Partial')
+        self.assertEqual(self.func_call_count, 1, "Expected function to be called once")
+
+    def test_EmitToLambda(self):
+        """Test emitting signal to lambda"""
+        lambdaSignal = PySignal.Signal()
+        lambdaSignal.connect(lambda value: testFunc(self, value))
+        lambdaSignal.emit('Lambda')
+        self.assertEqual(self.checkval, 'Lambda')
+        self.assertEqual(self.func_call_count, 1, "Expected function to be called once")
+
+    def test_EmitToMethod(self):
+        """Test emitting signal to method"""
         toSucceed = DummySignalClass()
         toSucceed.signal.connect(self.setVal)
-        toSucceed.signal.emit(20)
+        toSucceed.signal.emit('Method')
+        self.assertEqual(self.checkval, 'Method')
+        self.assertEqual(self.setVal_call_count, 1, "Expected function to be called once")
 
-        self.assertEqual(self.checkval, 20)
+    def test_EmitToMethodOnDeletedInstance(self):
+        """Test emitting signal to deleted instance method"""
+        toDelete = DummySlotClass()
+        toCall = PySignal.Signal()
+        toCall.connect(toDelete.setVal)
+        toCall.connect(self.setVal)
+        del toDelete
+        toCall.emit(1)
+        self.assertEqual(self.checkval, 1)
 
-    def test_classSignalEmit(self):
-        """Test if the class signal can be emitted but also that instances of the class are unique"""
+    def test_EmitToFunction(self):
+        """Test emitting signal to standalone function"""
+        funcSignal = PySignal.Signal()
+        funcSignal.connect(testFunc)
+        funcSignal.emit(self, 'Function')
+        self.assertEqual(self.checkval, 'Function')
+        self.assertEqual(self.func_call_count, 1, "Expected function to be called once")
+
+    def test_EmitToDeletedFunction(self):
+        """Test emitting signal to deleted instance method"""
+        def ToDelete(test, value):
+            test.checkVal = value
+            test.func_call_count += 1
+        funcSignal = PySignal.Signal()
+        funcSignal.connect(ToDelete)
+        del ToDelete
+        funcSignal.emit(self, 1)
+        self.assertEqual(self.checkval, None)
+        self.assertEqual(self.func_call_count, 0)
+
+    def test_PartialDisconnect(self):
+        """Test disconnecting partial function"""
+        partialSignal = PySignal.Signal()
+        part = partial(testFunc, self, 'Partial')
+        partialSignal.connect(part)
+        partialSignal.disconnect(part)
+        self.assertEqual(self.checkval, None, "Slot was not removed from signal")
+
+    def test_PartialDisconnectUnconnected(self):
+        """Test disconnecting unconnected partial function"""
+        partialSignal = PySignal.Signal()
+        part = partial(testFunc, self, 'Partial')
+        try:
+            partialSignal.disconnect(part)
+        except:
+            self.fail("Disonnecting unconnected partial should not raise")
+
+    def test_LambdaDisconnect(self):
+        """Test disconnecting lambda function"""
+        lambdaSignal = PySignal.Signal()
+        func = lambda value: testFunc(self, value)
+        lambdaSignal.connect(func)
+        lambdaSignal.disconnect(func)
+        self.assertEqual(len(lambdaSignal._slots), 0, "Slot was not removed from signal")
+
+    def test_LambdaDisconnectUnconnected(self):
+        """Test disconnecting unconnected lambda function"""
+        lambdaSignal = PySignal.Signal()
+        func = lambda value: testFunc(self, value)
+        try:
+            lambdaSignal.disconnect(func)
+        except:
+            self.fail("Disconnecting unconnected lambda should not raise")
+
+    def test_MethodDisconnect(self):
+        """Test disconnecting method"""
+        toCall = PySignal.Signal()
+        toCall.connect(self.setVal)
+        toCall.connect(self.setVal2)
+        toCall.disconnect(self.setVal2)
+        toCall.emit(1)
+        self.assertEqual(len(toCall._slots), 1, "Expected 1 connected after disconnect, found %d" % len(toCall._slots))
+        self.assertEqual(self.setVal_call_count, 1, "Expected function to be called once")
+        self.assertEqual(self.setVal2_call_count, 0, "Expected function to not be called after disconnecting")
+
+    def test_MethodDisconnectUnconnected(self):
+        """Test disconnecting unconnected method"""
+        toCall = PySignal.Signal()
+        try:
+            toCall.disconnect(self.setVal)
+        except:
+            self.fail("Disconnecting unconnected method should not raise")
+
+    def test_FunctionDisconnect(self):
+        """Test disconnecting function"""
+        funcSignal = PySignal.Signal()
+        funcSignal.connect(testFunc)
+        funcSignal.disconnect(testFunc)
+        self.assertEqual(len(funcSignal._slots), 0, "Slot was not removed from signal")
+
+    def test_FunctionDisconnectUnconnected(self):
+        """Test disconnecting unconnected function"""
+        funcSignal = PySignal.Signal()
+        try:
+            funcSignal.disconnect(testFunc)
+        except:
+            self.fail("Disconnecting unconnected function should not raise")
+
+    def test_DisconnectNonCallable(self):
+        """Test disconnecting non-callable object"""
+        signal = PySignal.Signal()
+        try:
+            signal.disconnect(self.checkval)
+        except:
+            self.fail("Disconnecting invalid object should not raise")
+
+    def test_ClearSlots(self):
+        """Test clearing all slots"""
+        multiSignal = PySignal.Signal()
+        func = lambda value: self.setVal(value)
+        multiSignal.connect(func)
+        multiSignal.connect(self.setVal)
+        multiSignal.clear()
+        self.assertEqual(len(multiSignal._slots), 0, "Not all slots were removed from signal")
+
+
+class ClassSignalTest(unittest.TestCase, SignalTestMixin):
+    """Unit tests for ClassSignal class"""
+
+    def setUp(self):
+        self.reset()
+
+    def __init__(self, methodName='runTest'):
+        unittest.TestCase.__init__(self, methodName)
+        SignalTestMixin.__init__(self)
+
+    def test_AssignToProperty(self):
+        """Test assigning to a ClassSignal property"""
+        dummy = DummySignalClass()
+        with self.assertRaises(RuntimeError):
+            dummy.cSignal = None
+
+    # noinspection PyUnresolvedReferences
+    def test_Emit(self):
+        """Test emitting signals from class signal and that instances of the class are unique"""
         toSucceed = DummySignalClass()
         toSucceed.cSignal.connect(self.setVal)
-
         toFail = DummySignalClass()
         toFail.cSignal.connect(self.throwaway)
+        toSucceed.cSignal.emit(1)
+        toFail.cSignal.emit(2)
+        self.assertEqual(self.checkval, 1)
 
-        toSucceed.cSignal.emit(50)
-        toFail.cSignal.emit(80)
 
-        self.assertEqual(self.checkval, 50)
+class SignalFactoryTest(unittest.TestCase, SignalTestMixin):
+    def __init__(self, methodName='runTest'):
+        unittest.TestCase.__init__(self, methodName)
+        SignalTestMixin.__init__(self)
 
-    def test_signalFactoryEmit(self):
-        """Test if the signal factory can emit signals"""
-        toSucceed = DummySignalClass()
-        toSucceed.signalFactory.register('Spam')
-        toSucceed.signalFactory['Spam'].connect(self.setVal)
+    def setUp(self):
+        self.reset()
 
-        toSucceed.signalFactory['Spam'].emit(22)
-
-        self.assertEqual(self.checkval, 22)
-
-    def test_cSignalFactoryEmit(self):
-        """Test if the class signal factory can emit signals but also that class instances are unique"""
+    # noinspection PyUnresolvedReferences
+    def test_Emit(self):
+        """Test emitting signals from class signal factory and that class instances are unique"""
         toSucceed = DummySignalClass()
         toSucceed.cSignalFactory.register('Spam')
         toSucceed.cSignalFactory['Spam'].connect(self.setVal)
-
         toFail = DummySignalClass()
         toFail.cSignalFactory.register('Spam')
         toFail.cSignalFactory['Spam'].connect(self.throwaway)
+        toSucceed.cSignalFactory['Spam'].emit(1)
+        toFail.cSignalFactory['Spam'].emit(2)
+        self.assertEqual(self.checkval, 1)
 
-        toSucceed.cSignalFactory['Spam'].emit(45)
-        toFail.cSignalFactory['Spam'].emit(12)
 
-        self.assertEqual(self.checkval, 45)
+class ClassSignalFactoryTest(unittest.TestCase, SignalTestMixin):
+    def __init__(self, methodName='runTest'):
+        unittest.TestCase.__init__(self, methodName)
+        SignalTestMixin.__init__(self)
 
-    def test_signalBlock(self):
-        """Test if the signal factory can block signals"""
+    def setUp(self):
+        self.checkval = None
+        self.checkval2 = None
+        self.setVal_call_count = 0
+        self.setVal2_call_count = 0
+        self.func_call_count = 0
+
+    def test_AssignToProperty(self):
+        """Test assigning to a ClassSignalFactory property"""
+        dummy = DummySignalClass()
+        with self.assertRaises(RuntimeError):
+            dummy.cSignalFactory = None
+
+    def test_Connect(self):
+        """Test SignalFactory indirect signal connection"""
+        dummy = DummySignalClass()
+        dummy.signalFactory.register('Spam')
+        dummy.signalFactory.connect('Spam', self.setVal)
+        dummy.signalFactory.emit('Spam', 1)
+        self.assertEqual(self.checkval, 1)
+        self.assertEqual(self.setVal_call_count, 1)
+
+    def test_ConnectInvalidChannel(self):
+        """Test SignalFactory connecting to invalid channel"""
+        dummy = DummySignalClass()
+        with self.assertRaises(AssertionError):
+            dummy.signalFactory.connect('Spam', self.setVal)
+
+    def test_Emit(self):
+        """Test emitting signals from signal factory"""
+        toSucceed = DummySignalClass()
+        toSucceed.signalFactory.register('Spam')
+        toSucceed.signalFactory['Spam'].connect(self.setVal)
+        toSucceed.signalFactory['Spam'].emit(1)
+        self.assertEqual(self.checkval, 1)
+
+    def test_BlockSingle(self):
+        """Test blocking single channel with signal factory"""
         dummy = DummySignalClass()
         dummy.signalFactory.register('Spam', self.setVal)
-        dummy.signalFactory['Spam'].emit(105)
+        dummy.signalFactory.register('Eggs', self.setVal2)
+        dummy.signalFactory.block('Spam')
+        dummy.signalFactory.emit('Spam', 1)
+        dummy.signalFactory.emit('Eggs', 2)
+        self.assertEqual(self.checkval, None)
+        self.assertEqual(self.checkval2, 2)
 
-        self.assertEqual(self.checkval, 105)
+    def test_UnblockSingle(self):
+        """Test unblocking a single channel with signal factory"""
+        dummy = DummySignalClass()
+        dummy.signalFactory.register('Spam', self.setVal)
+        dummy.signalFactory.register('Eggs', self.setVal2)
+        dummy.signalFactory.block('Spam')
+        dummy.signalFactory.block('Spam', False)
+        dummy.signalFactory.emit('Spam', 1)
+        dummy.signalFactory.emit('Eggs', 2)
+        self.assertEqual(self.checkval, 1)
+        self.assertEqual(self.checkval2, 2)
 
+    def test_BlockAll(self):
+        """Test blocking all signals from signal factory"""
+        dummy = DummySignalClass()
+        dummy.signalFactory.register('Spam', self.setVal)
+        dummy.signalFactory.register('Eggs', self.setVal2)
         dummy.signalFactory.block()
+        dummy.signalFactory.emit('Spam', 1)
+        dummy.signalFactory.emit('Eggs', 2)
+        self.assertEqual(self.checkval, None)
+        self.assertEqual(self.checkval2, None)
 
-        dummy.signalFactory['Spam'].emit(202)
-        self.assertNotEqual(self.checkval, 202)
+    def test_UnblockAll(self):
+        """Test unblocking all signals from signal factory"""
+        dummy = DummySignalClass()
+        dummy.signalFactory.register('Spam', self.setVal)
+        dummy.signalFactory.register('Eggs', self.setVal2)
+        dummy.signalFactory.block()
+        dummy.signalFactory.block(isBlocked=False)
+        dummy.signalFactory.emit('Spam', 1)
+        dummy.signalFactory.emit('Eggs', 2)
+        self.assertEqual(self.checkval, 1)
+        self.assertEqual(self.checkval2, 2)
+
+    def test_BlockInvalidChannel(self):
+        """Test blocking an invalid channel from signal factory"""
+        dummy = DummySignalClass()
+        with self.assertRaises(RuntimeError):
+            dummy.signalFactory.block('Spam')
+
+    def test_Deregister(self):
+        """Test unregistering from SignalFactory"""
+        dummy = DummySignalClass()
+        dummy.signalFactory.register('Spam')
+        dummy.signalFactory.deregister('Spam')
+        self.assertFalse('Spam' in dummy.signalFactory, "Signal not removed")
+
+    def test_DeregisterInvalidChannel(self):
+        """Test unregistering invalid channel from SignalFactory"""
+        dummy = DummySignalClass()
+        try:
+            dummy.signalFactory.deregister('Spam')
+        except KeyError:
+            self.fail("Deregistering invalid channel should not raise KeyError")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds test cases to increase code coverage to ~97+% (Remaining "uncovered" code paths were Python 2/3 compatibility fallbacks). Fixes a number of issues uncovered by new test cases.

I assumed that duplicate slot connections was unintended behavior and changed the behavior to ignore any additional connection attempts once a signal is connected to a given slot.