### PR TITLE
Added initial Signal.sender() method and simple weakref.WeakMethod backport.

### DIFF
--- a/PySignal.py
+++ b/PySignal.py
@@ -32,17 +32,18 @@ class Signal(object):
             return
 
         def _get_sender():
+            """Try to get the bound, class or module method calling the emit."""
             prev_frame = sys._getframe(2)
             func_name = prev_frame.f_code.co_name
             # Faster to try/catch than checking for 'self'
             try:
-                return getattr(prev_frame.f_locals['self'].__class__, func_name)
+                return getattr(prev_frame.f_locals['self'], func_name)
 
             except KeyError:
                 return getattr(inspect.getmodule(prev_frame), func_name)
 
         # Get the sender
-        self._sender = weakref.ref(_get_sender())
+        self._sender = weakref.WeakMethod(_get_sender())
 
         for slot in self._slots:
             if not slot:

--- a/PySignal.py
+++ b/PySignal.py
@@ -88,6 +88,7 @@ class Signal(object):
             """Try to get the bound, class or module method calling the emit."""
             prev_frame = sys._getframe(2)
             func_name = prev_frame.f_code.co_name
+
             # Faster to try/catch than checking for 'self'
             try:
                 return getattr(prev_frame.f_locals['self'], func_name)
@@ -96,7 +97,12 @@ class Signal(object):
                 return getattr(inspect.getmodule(prev_frame), func_name)
 
         # Get the sender
-        self._sender = WeakMethod(_get_sender())
+        try:
+            self._sender = WeakMethod(_get_sender())
+
+        # Account for when func_name is at '<module>'
+        except AttributeError:
+            self._sender = None
 
         for slot in self._slots:
             if not slot:

--- a/PySignal.py
+++ b/PySignal.py
@@ -2,7 +2,7 @@ __author__ = "Dhruv Govil"
 __copyright__ = "Copyright 2016, Dhruv Govil"
 __credits__ = ["Dhruv Govil", "John Hood", "Jason Viloria", "Adric Worley", "Alex Widener"]
 __license__ = "MIT"
-__version__ = "1.1.1"
+__version__ = "1.1.3"
 __maintainer__ = "Dhruv Govil"
 __email__ = "dhruvagovil@gmail.com"
 __status__ = "Beta"
@@ -47,13 +47,23 @@ except ImportError:
                     return None
 
                 else:
-                    return types.MethodType(func, obj)
+                    return types.MethodType(func, obj, obj.__class__)
 
             elif self._func is not None:
                 return self._func()
 
             else:
                 return None
+
+        def __eq__(self, other):
+            try:
+                return type(self) is type(other) and self() == other()
+
+            except Exception:
+                return False
+
+        def __ne__(self, other):
+            return not self.__eq__(other)
 
 
 class Signal(object):

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Signals allow for creating a callback interface on your object and allows for it
 For example I can define the following
 
 ```python
-
 class Foo(object):
     started = ClassSignal()
     ended = ClassSignal()
@@ -89,7 +88,7 @@ class Foo(object):
 This does a few things:
 
 * It guarantees that any instances of Foo or it's subclasses will always have the started and ended Signals. This allows for a guaranteed interface.
-* It means that when we want to add callbacks to Foo, we can do so on a case by case basis without having to subclass it to call the slots explicitely.
+* It means that when we want to add callbacks to Foo, we can do so on a case by case basis without having to subclass it to call the slots explicitly.
 
 For example:
 
@@ -104,7 +103,20 @@ foo1.run() # will output I am foo1
 foo2.run() # will output 42
 ```
 
-Instead of having to subclass `Foo` and implement the new behavior, we can simply reuse the exisitng Foo class and attach on to its instances.
+We can also get the Signal's "sender" - the bound method responsible for emitting the signal, if available.
+
+For example:
+
+```python
+bar_run1 = foo1.started.sender() # will output <bound method Foo.run of <__main__.Foo object at ...>>
+bar_run2 = foo2.started.sender() # will output <bound method Foo.run of <__main__.Foo object at ...>>
+
+print(bar_run1 == foo1.run) # will output True
+print(bar_run1 == foo2.run) # will output False
+print(bar_run1 == bar_run2) # will output False
+```
+
+Instead of having to subclass `Foo` and implement the new behavior, we can simply reuse the existing Foo class and attach on to its instances.
 
 ## What's missing?
 
@@ -143,6 +155,10 @@ SmokeSignal is another django inspired signal system.
 - It does not appear to support partials and lambdas.
 
 ## Changelog
+
+### 1.1.3
+
+* Basic support for retrieving a Signal's "sender", with some test coverage.
 
 ### 1.1.1
 

--- a/tests.py
+++ b/tests.py
@@ -306,6 +306,7 @@ class ClassSignalTest(unittest.TestCase, SignalTestMixin):
             dummy.cSignal = None
 
     def test_FunctionSender(self):
+        """Test correct Signal sender is found"""
         toSucceed = DummySignalClass()
         toSucceed.signal.connect(self.throwaway)
         toSucceed.triggerSignal()

--- a/tests.py
+++ b/tests.py
@@ -23,6 +23,9 @@ class DummySignalClass(object):
         self.signal = PySignal.Signal()
         self.signalFactory = PySignal.SignalFactory()
 
+    def triggerSignal(self):
+        self.signal.emit()
+
 
 class DummySlotClass(object):
     """A dummy class to check for slot handling"""
@@ -301,6 +304,12 @@ class ClassSignalTest(unittest.TestCase, SignalTestMixin):
         dummy = DummySignalClass()
         with self.assertRaises(RuntimeError):
             dummy.cSignal = None
+
+    def test_FunctionSender(self):
+        toSucceed = DummySignalClass()
+        toSucceed.signal.connect(self.throwaway)
+        toSucceed.triggerSignal()
+        self.assertEqual(DummySignalClass.triggerSignal, toSucceed.signal.sender())
 
     # noinspection PyUnresolvedReferences
     def test_Emit(self):

--- a/tests.py
+++ b/tests.py
@@ -14,6 +14,11 @@ def testFunc(test, value):
     test.func_call_count += 1
 
 
+def testLocalEmit(signal_instance):
+    """A test standalone function for signals to emit at local level"""
+    exec('signal_instance.emit()')
+
+
 class DummySignalClass(object):
     """A dummy class to check for instance handling of signals"""
     cSignal = PySignal.ClassSignal()
@@ -357,12 +362,19 @@ class ClassSignalTest(unittest.TestCase, SignalTestMixin):
         partial(toSucceed.triggerClassSignal)()
         self.assertEqual(toSucceed.triggerClassSignal, toSucceed.cSignal.sender())
 
-    def test_LocalSenderFound(self):
-        """Test correct Signal sender is found (local emit)"""
+    def test_SelfSenderFound(self):
+        """Test correct Signal sender is found (self emit)"""
         toSucceed = DummySignalClass()
         toSucceed.cSignal.connect(self.throwaway)
         toSucceed.cSignal.emit()
-        self.assertEqual(self.test_LocalSenderFound, toSucceed.cSignal.sender())
+        self.assertEqual(self.test_SelfSenderFound, toSucceed.cSignal.sender())
+
+    def test_LocalSenderHandled(self):
+        """Test correct Signal sender is found (module local emit)"""
+        toSucceed = DummySignalClass()
+        toSucceed.cSignal.connect(self.throwaway)
+        testLocalEmit(toSucceed.cSignal)
+        self.assertEqual(None, toSucceed.cSignal.sender())
 
 
 class SignalFactoryTest(unittest.TestCase, SignalTestMixin):


### PR DESCRIPTION
Added initial `Signal.sender()` method to return the method that called the Signal instance's last emit.

The `sender` is accessible from the Signal instance instead of its owner (lack of QObject).
Chose to treat the callable as the sender rather than the object for a couple of reasons;
1. As it doesn't have the reliance of QObject, callable is perhaps the most reliable option available (meaning we also treat the module as the object).
2. You can still get the object from the callable if needed.

Utilising `weakref.WeakMethod` and a functional backport for Python 2.7 to handle bound methods.