### PR TITLE
if the slot is a partial, pass the arguments

### DIFF
--- a/PySignal.py
+++ b/PySignal.py
@@ -116,7 +116,7 @@ class Signal(object):
             if not slot:
                 continue
             elif isinstance(slot, partial):
-                slot()
+                slot(*args, **kwargs)
             elif isinstance(slot, weakref.WeakKeyDictionary):
                 # For class methods, get the class object and call the method accordingly.
                 for obj, method in slot.items():


### PR DESCRIPTION
Hi,
@dgovil I'm not 100% sure, but it looks like you need to pass the arguments if the slot is a partial. This fixed the issue I was having. Let me know if you think it's correct. If so, can you please make a minor bugfix tag as well so it can get updated in conda-forge. I have a downstream package that relies on it.

Thanks!